### PR TITLE
Fixed Logging Panics

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,12 +42,12 @@ func Execute() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if err := cfg.Validate(); err != nil {
-				cfg.Logger.Error(err, "invalid configuration: %w", err)
+				cfg.Logger.Error(err, "invalid configuration")
 				return nil
 			}
 
 			if err := cfg.ParseModules(); err != nil {
-				cfg.Logger.Error(err, "invalid module configuration: %w", err)
+				cfg.Logger.Error(err, "invalid module configuration")
 				return nil
 			}
 


### PR DESCRIPTION
The otelcol-builder panics when it hits the fixed log lines with this error:

```
2021-02-10T10:46:30.641-0500	DPANIC	zapr@v0.2.0/zapr.go:133	odd number of arguments passed as key-value pairs for logging	{"ignored key": "invalid gomod specification for module, module: \"\""}
github.com/go-logr/zapr.handleFields
	github.com/go-logr/zapr@v0.2.0/zapr.go:100
github.com/go-logr/zapr.(*zapLogger).Error
	github.com/go-logr/zapr@v0.2.0/zapr.go:133
github.com/open-telemetry/opentelemetry-collector-builder/cmd.Execute.func1
	github.com/open-telemetry/opentelemetry-collector-builder/cmd/root.go:50
github.com/spf13/cobra.(*Command).execute
	github.com/spf13/cobra@v1.0.0/command.go:842
github.com/spf13/cobra.(*Command).ExecuteC
	github.com/spf13/cobra@v1.0.0/command.go:950
github.com/spf13/cobra.(*Command).Execute
	github.com/spf13/cobra@v1.0.0/command.go:887
github.com/open-telemetry/opentelemetry-collector-builder/cmd.Execute
	github.com/open-telemetry/opentelemetry-collector-builder/cmd/root.go:76
main.main
	github.com/open-telemetry/opentelemetry-collector-builder/main.go:22
runtime.main
	runtime/proc.go:203
panic: odd number of arguments passed as key-value pairs for logging
```