### PR TITLE
Explicitly enable GO111MODULE

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This program generates a custom OpenTelemetry Collector binary based on a given 
 
 ## TL;DR
 ```console
-$ go get github.com/open-telemetry/opentelemetry-collector-builder
+$ GO111MODULE=on go get github.com/open-telemetry/opentelemetry-collector-builder
 $ cat > ~/.otelcol-builder.yaml <<EOF
 exporters:
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.20.0"


### PR DESCRIPTION
As mentioned in this issue: https://github.com/open-telemetry/opentelemetry-collector-builder/issues/11
This PR sets the environment variable GO111MODULE
to avoid the error below when Go Modules is not enabled for some reason.

> cannot find package "github.com/hashicorp/hcl/hcl/printer" in any of:
>	/usr/local/Cellar/go/1.15.2/libexec/src/github.com/hashicorp/hcl/hcl/printer (from $GOROOT)
>	/Users/yang/go/src/github.com/hashicorp/hcl/hcl/printer (from $GOPATH)