### PR TITLE
update to 0.24.0 & update CombineErrors function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This program generates a custom OpenTelemetry Collector binary based on a given 
 $ GO111MODULE=on go get github.com/open-telemetry/opentelemetry-collector-builder
 $ cat > ~/.otelcol-builder.yaml <<EOF
 exporters:
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.23.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.24.0"
 EOF
 $ opentelemetry-collector-builder --output-path=/tmp/dist
 $ cat > /tmp/otelcol.yaml <<EOF
@@ -72,16 +72,16 @@ dist:
     name: otelcol-custom # the binary name. Optional.
     description: "Custom OpenTelemetry Collector distribution" # a long name for the application. Optional.
     include_core: true # whether the core components should be included in the distribution. Optional.
-    otelcol_version: "0.23.0" # the OpenTelemetry Collector version to use as base for the distribution. Optional.
+    otelcol_version: "0.24.0" # the OpenTelemetry Collector version to use as base for the distribution. Optional.
     output_path: /tmp/otelcol-distributionNNN # the path to write the output (sources and binary). Optional.
     version: "1.0.0" # the version for your custom OpenTelemetry Collector. Optional.
     go: "/usr/bin/go" # which Go binary to use to compile the generated sources. Optional.
 exporters:
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.23.0" # the Go module for the component. Required.
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.24.0" # the Go module for the component. Required.
     import: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter" # the import path for the component. Optional.
     name: "alibabacloudlogserviceexporter" # package name to use in the generated sources. Optional.
     path: "./alibabacloudlogserviceexporter" # in case a local version should be used for the module, the path relative to the current dir, or a full path can be specified. Optional.
 replaces:
   # a list of "replaces" directives that will be part of the resulting go.mod
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.23.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.24.0
 ```

--- a/internal/builder/config.go
+++ b/internal/builder/config.go
@@ -26,7 +26,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultOtelColVersion = "0.23.0"
+const defaultOtelColVersion = "0.24.0"
 
 // ErrInvalidGoMod indicates an invalid gomod
 var ErrInvalidGoMod = errors.New("invalid gomod specification for module")

--- a/internal/scaffold/components.go
+++ b/internal/scaffold/components.go
@@ -125,6 +125,6 @@ func components() (component.Factories, error) {
 		errs = append(errs, err)
 	}
 
-	return factories, consumererror.CombineErrors(errs)
+	return factories, consumererror.Combine(errs)
 }
 `

--- a/test/nocore.builder.yaml
+++ b/test/nocore.builder.yaml
@@ -1,6 +1,6 @@
 dist:
   module: github.com/open-telemetry/opentelemetry-collector-builder/test/nocore
-  otelcol_version: 0.23.0
+  otelcol_version: 0.24.0
   include_core: false
 
 receivers:

--- a/test/replaces.builder.yaml
+++ b/test/replaces.builder.yaml
@@ -1,10 +1,10 @@
 dist:
   module: github.com/open-telemetry/opentelemetry-collector-builder/test/replaces
-  otelcol_version: 0.23.0
+  otelcol_version: 0.24.0
 
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.23.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.23.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.24.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.24.0
 
 replaces:
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.23.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.24.0


### PR DESCRIPTION
Closes #31 

Updating to OTEL 0.24.0 and update the related `CombineErrors `function