### PR TITLE
Don't use %w formatting with log.Fatal

### DIFF
--- a/internal/scaffold/main.go
+++ b/internal/scaffold/main.go
@@ -55,12 +55,12 @@ func main() {
 
 	app, err := service.New(service.Parameters{ApplicationStartInfo: info, Factories: factories})
 	if err != nil {
-		log.Fatal("failed to construct the application: %w", err)
+		log.Fatalf("failed to construct the application: %v", err)
 	}
 
 	err = app.Run()
 	if err != nil {
-		log.Fatal("application run finished with error: %w", err)
+		log.Fatalf("application run finished with error: %v", err)
 	}
 }
 `


### PR DESCRIPTION
`log.Fatal()` doesn't seem to understand `%w` format specifier so use `log.Fatalf()` and `%v` instead.

This will fix the below error from:

```
Error: cannot load configuration: config file not specified
2021/04/15 11:35:27 application run finished with error: %wcannot load configuration: config file not specified
```

into

```
Error: cannot load configuration: config file not specified
2021/04/15 11:37:31 application run finished with error: cannot load configuration: config file not specified
```