### PR TITLE
Add security workflow (2/2): CodeQL scan

### DIFF
--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -1,0 +1,24 @@
+name: "CodeQL Analysis"
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  CodeQL-Build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: go
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
## Motivation
Follow up to PR #45 and issue open-telemetry/oteps#144

[CodeQL](https://github.com/github/codeql) is GitHub's static analysis engine which scans repos for security vulnerabilities. As the project grows and we near GA it might be useful to have a workflow which checks for security vulnerabilities with every PR so we can ensure every incremental change is following best development practices. Also passing basic security checks will also make sure that there aren't any glaring issues for our users.

## Changes
This PR adds CodeQL security checks to the repo
* After every run the workflow uploads the results to GitHub. Details on the run and security alerts will show up in the security tab of this repo.

**Workflow Triggers**
* on commit to main (to match what is being done in the [Collector repo](https://github.com/open-telemetry/opentelemetry-collector/pull/2915/files))
* workflow_dispatch (in case maintainers want to trigger a security check manually)

cc- @alolita