### PR TITLE
Update to Collector v0.28.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This program generates a custom OpenTelemetry Collector binary based on a given 
 $ GO111MODULE=on go get github.com/open-telemetry/opentelemetry-collector-builder
 $ cat > ~/.otelcol-builder.yaml <<EOF
 exporters:
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.27.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.28.0"
 EOF
 $ opentelemetry-collector-builder --output-path=/tmp/dist
 $ cat > /tmp/otelcol.yaml <<EOF
@@ -73,16 +73,16 @@ dist:
     name: otelcol-custom # the binary name. Optional.
     description: "Custom OpenTelemetry Collector distribution" # a long name for the application. Optional.
     include_core: true # whether the core components should be included in the distribution. Optional.
-    otelcol_version: "0.27.0" # the OpenTelemetry Collector version to use as base for the distribution. Optional.
+    otelcol_version: "0.28.0" # the OpenTelemetry Collector version to use as base for the distribution. Optional.
     output_path: /tmp/otelcol-distributionNNN # the path to write the output (sources and binary). Optional.
     version: "1.0.0" # the version for your custom OpenTelemetry Collector. Optional.
     go: "/usr/bin/go" # which Go binary to use to compile the generated sources. Optional.
 exporters:
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.27.0" # the Go module for the component. Required.
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.28.0" # the Go module for the component. Required.
     import: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter" # the import path for the component. Optional.
     name: "alibabacloudlogserviceexporter" # package name to use in the generated sources. Optional.
     path: "./alibabacloudlogserviceexporter" # in case a local version should be used for the module, the path relative to the current dir, or a full path can be specified. Optional.
 replaces:
   # a list of "replaces" directives that will be part of the resulting go.mod
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.27.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.28.0
 ```

--- a/internal/builder/config.go
+++ b/internal/builder/config.go
@@ -26,7 +26,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultOtelColVersion = "0.27.0"
+const defaultOtelColVersion = "0.28.0"
 
 // ErrInvalidGoMod indicates an invalid gomod
 var ErrInvalidGoMod = errors.New("invalid gomod specification for module")

--- a/internal/builder/main.go
+++ b/internal/builder/main.go
@@ -130,7 +130,7 @@ func GetModules(cfg Config) error {
 	retries := 3
 	failReason := "unknown"
 	for i := 1; i <= retries; i++ {
-		cmd := exec.Command(goBinary, "mod", "download")
+		cmd := exec.Command(goBinary, "mod", "tidy")
 		cmd.Dir = cfg.Distribution.OutputPath
 		if out, err := cmd.CombinedOutput(); err != nil {
 			failReason = fmt.Sprintf("%s. Output: %q", err, out)

--- a/internal/scaffold/main.go
+++ b/internal/scaffold/main.go
@@ -53,7 +53,7 @@ func main() {
 		Version:  "{{ .Distribution.Version }}",
 	}
 
-	app, err := service.New(service.Parameters{BuildInfo: info, Factories: factories})
+	app, err := service.New(service.AppSettings{BuildInfo: info, Factories: factories})
 	if err != nil {
 		log.Fatalf("failed to construct the application: %v", err)
 	}

--- a/test/nocore.builder.yaml
+++ b/test/nocore.builder.yaml
@@ -1,6 +1,6 @@
 dist:
   module: github.com/open-telemetry/opentelemetry-collector-builder/test/nocore
-  otelcol_version: 0.27.0
+  otelcol_version: 0.28.0
   include_core: false
 
 receivers:

--- a/test/replaces.builder.yaml
+++ b/test/replaces.builder.yaml
@@ -1,10 +1,10 @@
 dist:
   module: github.com/open-telemetry/opentelemetry-collector-builder/test/replaces
-  otelcol_version: 0.27.0
+  otelcol_version: 0.28.0
 
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.27.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.27.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.28.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.28.0
 
 replaces:
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.27.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.28.0


### PR DESCRIPTION
Closes #48

Addresses the breaking API change in
https://github.com/open-telemetry/opentelemetry-collector/pull/3163,
besides the usual version number changes.

Signed-off-by: Fangyi Zhou <me@fangyi.io>