### PR TITLE
Account for go mod download in go1.17 not updating go.sum

### DIFF
--- a/internal/builder/main.go
+++ b/internal/builder/main.go
@@ -130,7 +130,7 @@ func GetModules(cfg Config) error {
 	retries := 3
 	failReason := "unknown"
 	for i := 1; i <= retries; i++ {
-		cmd := exec.Command(goBinary, "mod", "tidy")
+		cmd := exec.Command(goBinary, "mod", "download", "all")
 		cmd.Dir = cfg.Distribution.OutputPath
 		if out, err := cmd.CombinedOutput(); err != nil {
 			failReason = fmt.Sprintf("%s. Output: %q", err, out)


### PR DESCRIPTION
Because the behaviour of `go mod download` changes in go1.17 we need to account for that. For previous versions this will result in the same behaviour.

> `go mod download`
> When `go mod download` is invoked without arguments, it will no longer save sums for downloaded module content to go.sum. It may still make changes to go.mod and go.sum needed to load the build list. This is the same as the behavior in Go 1.15. To save sums for all modules, use `go mod download all`.

ref: https://tip.golang.org/doc/go1.17