### PR TITLE
cmd: fix module flag default value to github.com/open-telemetry

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,7 +76,7 @@ func Execute() error {
 	cmd.Flags().StringVar(&cfg.Distribution.OtelColVersion, "otelcol-version", cfg.Distribution.OtelColVersion, "Which version of OpenTelemetry Collector to use as base")
 	cmd.Flags().StringVar(&cfg.Distribution.OutputPath, "output-path", cfg.Distribution.OutputPath, "Where to write the resulting files")
 	cmd.Flags().StringVar(&cfg.Distribution.Go, "go", "/usr/bin/go", "The Go binary to use during the compilation phase")
-	cmd.Flags().StringVar(&cfg.Distribution.Module, "module", "github.com/jpkroehling/opentelemetry-collector-builder", "The Go module for the new distribution")
+	cmd.Flags().StringVar(&cfg.Distribution.Module, "module", "github.com/open-telemetry/opentelemetry-collector-builder", "The Go module for the new distribution")
 
 	// version of this binary
 	cmd.AddCommand(versionCmd)


### PR DESCRIPTION
Fix `-module` flag default value to `github.com/open-telemetry`.