### PR TITLE
Add excludes support to generated go.mod

### DIFF
--- a/internal/builder/config.go
+++ b/internal/builder/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	Receivers    []Module     `mapstructure:"receivers"`
 	Processors   []Module     `mapstructure:"processors"`
 	Replaces     []string     `mapstructure:"replaces"`
+	Excludes     []string     `mapstructure:"excludes"`
 }
 
 // Distribution holds the parameters for the final binary

--- a/internal/scaffold/gomod.go
+++ b/internal/scaffold/gomod.go
@@ -50,4 +50,7 @@ require (
 {{- range .Replaces}}
 replace {{.}}
 {{- end}}
+{{- range .Excludes}}
+exclude {{.}}
+{{- end}}
 `


### PR DESCRIPTION
This was necessary to avoid an issue I encountered with a transient dependency that had apparently retagged a tag already observed by sumdb.  It seems simple and generally useful enough to include.

Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>