### PR TITLE
Update to OpenTelemetry core 0.34.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This program generates a custom OpenTelemetry Collector binary based on a given 
 $ GO111MODULE=on go get github.com/open-telemetry/opentelemetry-collector-builder
 $ cat > ~/.otelcol-builder.yaml <<EOF
 exporters:
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.33.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.34.0"
 EOF
 $ opentelemetry-collector-builder --output-path=/tmp/dist
 $ cat > /tmp/otelcol.yaml <<EOF
@@ -73,16 +73,16 @@ dist:
     name: otelcol-custom # the binary name. Optional.
     description: "Custom OpenTelemetry Collector distribution" # a long name for the application. Optional.
     include_core: true # whether the core components should be included in the distribution. Optional.
-    otelcol_version: "0.33.0" # the OpenTelemetry Collector version to use as base for the distribution. Optional.
+    otelcol_version: "0.34.0" # the OpenTelemetry Collector version to use as base for the distribution. Optional.
     output_path: /tmp/otelcol-distributionNNN # the path to write the output (sources and binary). Optional.
     version: "1.0.0" # the version for your custom OpenTelemetry Collector. Optional.
     go: "/usr/bin/go" # which Go binary to use to compile the generated sources. Optional.
 exporters:
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.33.0" # the Go module for the component. Required.
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.34.0" # the Go module for the component. Required.
     import: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter" # the import path for the component. Optional.
     name: "alibabacloudlogserviceexporter" # package name to use in the generated sources. Optional.
     path: "./alibabacloudlogserviceexporter" # in case a local version should be used for the module, the path relative to the current dir, or a full path can be specified. Optional.
 replaces:
   # a list of "replaces" directives that will be part of the resulting go.mod
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.33.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.34.0
 ```

--- a/internal/builder/config.go
+++ b/internal/builder/config.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultOtelColVersion = "0.33.0"
+const defaultOtelColVersion = "0.34.0"
 
 // ErrInvalidGoMod indicates an invalid gomod
 var ErrInvalidGoMod = errors.New("invalid gomod specification for module")

--- a/internal/builder/main.go
+++ b/internal/builder/main.go
@@ -110,7 +110,7 @@ func Compile(cfg Config) error {
 // GetModules retrieves the go modules, updating go.mod and go.sum in the process
 func GetModules(cfg Config) error {
 	// #nosec G204
-	cmd := exec.Command(cfg.Distribution.Go, "mod", "tidy")
+	cmd := exec.Command(cfg.Distribution.Go, "mod", "tidy", "-compat=1.17")
 	cmd.Dir = cfg.Distribution.OutputPath
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to update go.mod: %w. Output: %q", err, out)

--- a/test/nocore.builder.yaml
+++ b/test/nocore.builder.yaml
@@ -1,14 +1,14 @@
 dist:
   module: github.com/open-telemetry/opentelemetry-collector-builder/test/nocore
-  otelcol_version: 0.33.0
+  otelcol_version: 0.34.0
   include_core: false
 
 receivers:
-  - import: go.opentelemetry.io/collector/receiver/jaegerreceiver
+  - import: go.opentelemetry.io/collector/receiver/otlpreceiver
     core: true
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
     core: true
 extensions:
-  - import: go.opentelemetry.io/collector/extension/healthcheckextension
+  - import: go.opentelemetry.io/collector/extension/zpagesextension
     core: true

--- a/test/nocore.otel.yaml
+++ b/test/nocore.otel.yaml
@@ -1,13 +1,10 @@
 extensions:
-  health_check:
+  zpages:
 
 receivers:
-  jaeger:
+  otlp:
     protocols:
       grpc:
-      thrift_http:
-      thrift_compact:
-      thrift_binary:
 
 processors:
 
@@ -15,11 +12,11 @@ exporters:
   logging:
 
 service:
-  extensions: [health_check]
+  extensions: [zpages]
   pipelines:
     traces:
       receivers:
-        - jaeger
+        - otlp
       processors: []
       exporters:
         - logging

--- a/test/replaces.builder.yaml
+++ b/test/replaces.builder.yaml
@@ -1,10 +1,10 @@
 dist:
   module: github.com/open-telemetry/opentelemetry-collector-builder/test/replaces
-  otelcol_version: 0.33.0
+  otelcol_version: 0.34.0
 
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.33.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.33.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.34.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.34.0
 
 replaces:
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.33.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.34.0

--- a/test/replaces.otel.yaml
+++ b/test/replaces.otel.yaml
@@ -1,5 +1,5 @@
 extensions:
-  health_check:
+  zpages:
 
 receivers:
   otlp:
@@ -24,7 +24,7 @@ exporters:
   logging:
 
 service:
-  extensions: [health_check]
+  extensions: [zpages]
   pipelines:
     traces:
       receivers:

--- a/test/test.sh
+++ b/test/test.sh
@@ -62,7 +62,7 @@ do
             break
         fi
 
-        curl -s localhost:13133  | grep "Server available" > /dev/null
+        curl -s http://localhost:55679/debug/servicez | grep Uptime > /dev/null
         if [ $? == 0 ]; then
             echo "✅ PASS ${test}"
 


### PR DESCRIPTION
Fixes #67

Core v0.34.0 brought a few breaking changes, which requires a few changes to the tests to the builder.

I also faced a problem with Go 1.17 that I didn't when working on #65, fixed by the "compat=1.17" flag to "go mod tidy". This effectively makes the builder to require Go 1.17, which sounds reasonable at this point.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>